### PR TITLE
fix: add i18n support for table labels and all hardcoded strings

### DIFF
--- a/webview-react/src/components/ContextMenu.tsx
+++ b/webview-react/src/components/ContextMenu.tsx
@@ -194,7 +194,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         >
           <button className="context-menu-item" onClick={() => { onImportCsv?.(); onClose(); }}>
             <span className="context-menu-icon">📥</span>
-            <span className="context-menu-label">Import CSV (Auto)</span>
+            <span className="context-menu-label">{t('importCsvAuto')}</span>
           </button>
           <div className="context-menu-separator"></div>
           <button className="context-menu-item" onClick={() => { onToggleColumnHeaders?.(); onClose(); }}>

--- a/webview-react/src/components/SearchBar.tsx
+++ b/webview-react/src/components/SearchBar.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
 import { SearchState, SearchScope } from '../types'
 
 interface SearchBarProps {
@@ -32,6 +33,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   onToggleAdvanced,
   onScopeChange
 }) => {
+  const { t } = useTranslation()
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   // 検索バーが開いたときに検索入力にフォーカス
@@ -85,7 +87,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             ref={searchInputRef}
             type="text"
             className="search-input"
-            placeholder="検索..."
+            placeholder={t('searchBar.searchPlaceholder')}
             value={searchState.searchText}
             onChange={(e) => onSearchTextChange(e.target.value)}
             onKeyDown={handleSearchKeyDown}
@@ -94,14 +96,14 @@ const SearchBar: React.FC<SearchBarProps> = ({
             <span className="search-result-count">
               {currentResultInfo.total > 0
                 ? `${currentResultInfo.current}/${currentResultInfo.total}`
-                : '一致なし'}
+                : t('searchBar.noMatches')}
             </span>
           )}
         </div>
         <div className="search-actions">
           <button
             className="search-nav-button"
-            title="前を検索 (Shift+Enter)"
+            title={t('searchBar.previousTitle')}
             onClick={onFindPrevious}
             disabled={currentResultInfo.total === 0}
           >
@@ -109,7 +111,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
           </button>
           <button
             className="search-nav-button"
-            title="次を検索 (Enter)"
+            title={t('searchBar.nextTitle')}
             onClick={onFindNext}
             disabled={currentResultInfo.total === 0}
           >
@@ -117,35 +119,35 @@ const SearchBar: React.FC<SearchBarProps> = ({
           </button>
           <button
             className={`search-option-button ${searchState.options.caseSensitive ? 'active' : ''}`}
-            title="大文字小文字を区別"
+            title={t('searchBar.caseSensitiveTitle')}
             onClick={() => onToggleOption('caseSensitive')}
           >
             Aa
           </button>
           <button
             className={`search-option-button ${searchState.options.wholeWord ? 'active' : ''}`}
-            title="完全一致"
+            title={t('searchBar.wholeWordTitle')}
             onClick={() => onToggleOption('wholeWord')}
           >
             Ab
           </button>
           <button
             className={`search-option-button ${searchState.options.regex ? 'active' : ''}`}
-            title="正規表現"
+            title={t('searchBar.regexTitle')}
             onClick={() => onToggleOption('regex')}
           >
             .*
           </button>
           <button
             className={`search-advanced-button ${searchState.showAdvanced ? 'active' : ''}`}
-            title="詳細設定"
+            title={t('searchBar.advancedTitle')}
             onClick={onToggleAdvanced}
           >
             ⚙
           </button>
           <button
             className="search-close-button"
-            title="閉じる (Esc)"
+            title={t('searchBar.closeTitle')}
             onClick={onClose}
           >
             ✕
@@ -160,7 +162,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
             <input
               type="text"
               className="search-input"
-              placeholder="置換..."
+              placeholder={t('searchBar.replacePlaceholder')}
               value={searchState.replaceText}
               onChange={(e) => onReplaceTextChange(e.target.value)}
               onKeyDown={handleReplaceKeyDown}
@@ -169,19 +171,19 @@ const SearchBar: React.FC<SearchBarProps> = ({
           <div className="search-actions">
             <button
               className="replace-button"
-              title="置換"
+              title={t('searchBar.replaceTitle')}
               onClick={onReplaceOne}
               disabled={currentResultInfo.total === 0}
             >
-              置換
+              {t('searchBar.replaceButton')}
             </button>
             <button
               className="replace-all-button"
-              title="すべて置換"
+              title={t('searchBar.replaceAllTitle')}
               onClick={onReplaceAll}
               disabled={currentResultInfo.total === 0}
             >
-              すべて置換
+              {t('searchBar.replaceAllButton')}
             </button>
           </div>
         </div>
@@ -189,15 +191,15 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
       {searchState.showAdvanced && (
         <div className="advanced-row">
-          <label className="scope-label">検索範囲:</label>
+          <label className="scope-label">{t('searchBar.scopeLabel')}</label>
           <select
             className="scope-select"
             value={searchState.scope}
             onChange={(e) => onScopeChange(e.target.value as SearchScope)}
           >
-            <option value="all">すべてのシート</option>
-            <option value="current">現在のシート</option>
-            <option value="selection">選択中のセル</option>
+            <option value="all">{t('searchBar.scopeAll')}</option>
+            <option value="current">{t('searchBar.scopeCurrent')}</option>
+            <option value="selection">{t('searchBar.scopeSelection')}</option>
           </select>
         </div>
       )}

--- a/webview-react/src/components/SortActions.tsx
+++ b/webview-react/src/components/SortActions.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 interface SortActionsProps {
   onCommitSort: () => void
   onRestoreOriginal: () => void
@@ -7,14 +9,16 @@ const SortActions: React.FC<SortActionsProps> = ({
   onCommitSort,
   onRestoreOriginal
 }) => {
+  const { t } = useTranslation()
+
   return (
     <div className="sort-actions visible">
-      <span className="sort-status-badge">📊 Viewing sorted data</span>
+      <span className="sort-status-badge">{t('sortActions.viewingSorted')}</span>
       <button className="sort-action-btn secondary" onClick={onRestoreOriginal}>
-        📄 Restore Original
+        {t('sortActions.restoreOriginal')}
       </button>
       <button className="sort-action-btn" onClick={onCommitSort}>
-        💾 Save Sort to File
+        {t('sortActions.saveSortToFile')}
       </button>
     </div>
   )

--- a/webview-react/src/components/TableTabs.tsx
+++ b/webview-react/src/components/TableTabs.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { TableData } from '../types'
 
 interface TableTabsProps {
@@ -11,6 +12,8 @@ const TableTabs: React.FC<TableTabsProps> = ({
   currentTableIndex,
   onTabChange
 }) => {
+  const { t } = useTranslation()
+
   if (tables.length <= 1) {
     return null
   }
@@ -25,7 +28,7 @@ const TableTabs: React.FC<TableTabsProps> = ({
             onTabChange(index)
           }}
         >
-          表 {index + 1}
+          {t('tableTabs.tableLabel', { index: index + 1 })}
         </button>
       ))}
     </div>

--- a/webview-react/src/locales/en.json
+++ b/webview-react/src/locales/en.json
@@ -50,5 +50,34 @@
     "saved": "Auto-saved",
     "sorted": "Display order is sorted",
     "rowsColumns": "{{rows}} rows × {{columns}} columns"
-  }
+  },
+  "tableTabs": {
+    "tableLabel": "Table {{index}}"
+  },
+  "searchBar": {
+    "searchPlaceholder": "Search...",
+    "noMatches": "No matches",
+    "previousTitle": "Previous Match (Shift+Enter)",
+    "nextTitle": "Next Match (Enter)",
+    "caseSensitiveTitle": "Match Case",
+    "wholeWordTitle": "Match Whole Word",
+    "regexTitle": "Use Regular Expression",
+    "advancedTitle": "Advanced Settings",
+    "closeTitle": "Close (Esc)",
+    "replacePlaceholder": "Replace...",
+    "replaceTitle": "Replace",
+    "replaceButton": "Replace",
+    "replaceAllTitle": "Replace All",
+    "replaceAllButton": "Replace All",
+    "scopeLabel": "Search Scope:",
+    "scopeAll": "All Tables",
+    "scopeCurrent": "Current Table",
+    "scopeSelection": "Selected Cells"
+  },
+  "sortActions": {
+    "viewingSorted": "📊 Viewing sorted data",
+    "restoreOriginal": "📄 Restore Original",
+    "saveSortToFile": "💾 Save Sort to File"
+  },
+  "importCsvAuto": "Import CSV (Auto)"
 }

--- a/webview-react/src/locales/ja.json
+++ b/webview-react/src/locales/ja.json
@@ -50,5 +50,34 @@
     "saved": "自動保存済み",
     "sorted": "表示順序はソートされています",
     "rowsColumns": "{{rows}} 行 × {{columns}} 列"
-  }
+  },
+  "tableTabs": {
+    "tableLabel": "表 {{index}}"
+  },
+  "searchBar": {
+    "searchPlaceholder": "検索...",
+    "noMatches": "一致なし",
+    "previousTitle": "前を検索 (Shift+Enter)",
+    "nextTitle": "次を検索 (Enter)",
+    "caseSensitiveTitle": "大文字小文字を区別",
+    "wholeWordTitle": "完全一致",
+    "regexTitle": "正規表現",
+    "advancedTitle": "詳細設定",
+    "closeTitle": "閉じる (Esc)",
+    "replacePlaceholder": "置換...",
+    "replaceTitle": "置換",
+    "replaceButton": "置換",
+    "replaceAllTitle": "すべて置換",
+    "replaceAllButton": "すべて置換",
+    "scopeLabel": "検索範囲:",
+    "scopeAll": "すべてのシート",
+    "scopeCurrent": "現在のシート",
+    "scopeSelection": "選択中のセル"
+  },
+  "sortActions": {
+    "viewingSorted": "📊 ソート済みデータを表示中",
+    "restoreOriginal": "📄 元の順序を復元",
+    "saveSortToFile": "💾 ソート順をファイルに保存"
+  },
+  "importCsvAuto": "Import CSV (Auto)"
 }

--- a/webview-react/src/locales/zh-cn.json
+++ b/webview-react/src/locales/zh-cn.json
@@ -50,5 +50,34 @@
     "saved": "已自动保存",
     "sorted": "显示顺序已排序",
     "rowsColumns": "{{rows}} 行 × {{columns}} 列"
-  }
+  },
+  "tableTabs": {
+    "tableLabel": "表 {{index}}"
+  },
+  "searchBar": {
+    "searchPlaceholder": "搜索...",
+    "noMatches": "无匹配项",
+    "previousTitle": "上一个匹配 (Shift+Enter)",
+    "nextTitle": "下一个匹配 (Enter)",
+    "caseSensitiveTitle": "区分大小写",
+    "wholeWordTitle": "全字匹配",
+    "regexTitle": "正则表达式",
+    "advancedTitle": "高级设置",
+    "closeTitle": "关闭 (Esc)",
+    "replacePlaceholder": "替换...",
+    "replaceTitle": "替换",
+    "replaceButton": "替换",
+    "replaceAllTitle": "全部替换",
+    "replaceAllButton": "全部替换",
+    "scopeLabel": "搜索范围:",
+    "scopeAll": "所有表格",
+    "scopeCurrent": "当前表格",
+    "scopeSelection": "选中的单元格"
+  },
+  "sortActions": {
+    "viewingSorted": "📊 查看已排序的数据",
+    "restoreOriginal": "📄 恢复原始顺序",
+    "saveSortToFile": "💾 保存排序到文件"
+  },
+  "importCsvAuto": "导入CSV (自动)"
 }


### PR DESCRIPTION
- Add translation keys for table tabs label ("Table {n}")
- Add translation keys for all SearchBar hardcoded strings (search, replace, options)
- Add translation keys for SortActions component strings
- Add translation keys for ContextMenu "Import CSV (Auto)" label
- Update all three locale files (en, ja, zh-cn) with new translations
- Replace all hardcoded strings in components with i18n calls using useTranslation hook

This ensures proper multilingual support across the entire UI.