### PR TITLE
refactor: deduplicate types and extract common handlers

### DIFF
--- a/src/gitDiffTypes.ts
+++ b/src/gitDiffTypes.ts
@@ -1,0 +1,42 @@
+export enum GitDiffStatus {
+    UNCHANGED = 'unchanged',
+    ADDED = 'added',
+    MODIFIED = 'modified',
+    DELETED = 'deleted'
+}
+
+export interface RowGitDiff {
+    row: number;
+    status: GitDiffStatus;
+    oldContent?: string;
+    newContent?: string;
+    isDeletedRow?: boolean;
+    targetRow?: number;
+}
+
+export interface TableGitDiff {
+    tableIndex: number;
+    rows: RowGitDiff[];
+}
+
+export interface ColumnPositionChange {
+    index: number;
+    type: 'added' | 'removed' | 'renamed';
+    header?: string;
+    confidence: number;
+    oldIndex?: number;
+    newIndex?: number;
+}
+
+export interface ColumnDiffInfo {
+    oldColumnCount: number;
+    newColumnCount: number;
+    addedColumns: number[];
+    deletedColumns: number[];
+    oldHeaders?: string[];
+    newHeaders?: string[];
+    changeType?: 'added' | 'removed' | 'mixed' | 'none';
+    positions?: ColumnPositionChange[];
+    mapping?: number[];
+    heuristics?: string[];
+}

--- a/src/gitDiffUtils.ts
+++ b/src/gitDiffUtils.ts
@@ -6,67 +6,9 @@
 
 import * as vscode from 'vscode';
 import { debug, warn, error } from './logging';
+import { GitDiffStatus, type RowGitDiff, type ColumnDiffInfo } from './gitDiffTypes';
 
-/**
- * セルのGit差分状態
- * MODIFIED は廃止。変更は DELETED + ADDED で表現し、oldContent で変更前の内容を保持
- */
-export enum GitDiffStatus {
-    UNCHANGED = 'unchanged',
-    ADDED = 'added',
-    DELETED = 'deleted'
-}
-
-
-/**
- * 行のGit差分情報
- */
-export interface RowGitDiff {
-    row: number;
-    status: GitDiffStatus;
-    oldContent?: string;  // 削除された行の内容（変更前の行を表示するため）
-    newContent?: string;  // 追加された行の内容（列差分検出用）
-    isDeletedRow?: boolean;  // 削除行の表示用フラグ（実データ行ではない）
-    targetRow?: number;  // 削除行のセル比較対象となる追加行のテーブル行番号
-}
-
-/**
- * テーブルのGit差分情報
- */
-export interface TableGitDiff {
-    tableIndex: number;
-    rows: RowGitDiff[];
-}
-
-/**
- * 列の位置変更情報
- * 中間列の追加・削除を検知した際の詳細情報
- */
-export interface ColumnPositionChange {
-    index: number;              // 変更位置（追加の場合は新しい列番号、削除の場合は旧列番号）
-    type: 'added' | 'removed' | 'renamed';
-    header?: string;            // ヘッダ名（わかる場合）
-    confidence: number;         // 検出信頼度（0.0〜1.0）
-    oldIndex?: number;          // renamed時の旧インデックス
-    newIndex?: number;          // renamed時の新インデックス
-}
-
-/**
- * 列の差分情報
- * 変更前と変更後の列数を比較して、追加・削除された列を検出
- */
-export interface ColumnDiffInfo {
-    oldColumnCount: number;      // 変更前の列数
-    newColumnCount: number;      // 変更後の列数
-    addedColumns: number[];      // 追加された列のインデックス（変更後の列番号）
-    deletedColumns: number[];    // 削除された列のインデックス（変更前の列番号）
-    oldHeaders?: string[];       // 変更前のヘッダ（削除列表示用）
-    newHeaders?: string[];       // 変更後のヘッダ
-    changeType?: 'added' | 'removed' | 'mixed' | 'none';  // 変更種別
-    positions?: ColumnPositionChange[];  // 各位置の変更詳細
-    mapping?: number[];          // 旧インデックス→新インデックスのマッピング（-1は削除）
-    heuristics?: string[];       // 適用した検出手法のメモ
-}
+export { GitDiffStatus, type RowGitDiff, type TableGitDiff, type ColumnPositionChange, type ColumnDiffInfo } from './gitDiffTypes';
 
 /**
  * VS Code Git APIを使用してリポジトリを取得し、状態を更新する

--- a/webview-react/src/components/ContextMenu.tsx
+++ b/webview-react/src/components/ContextMenu.tsx
@@ -1,15 +1,11 @@
 import { useTranslation } from 'react-i18next'
 import { useDynamicTheme } from '../contexts/DynamicThemeContext'
+import type { HeaderConfig } from '../types'
 
 interface ContextMenuState {
   type: 'row' | 'column' | 'editor' | null
   index: number
   position: { x: number; y: number }
-}
-
-interface HeaderConfig {
-  hasColumnHeaders: boolean
-  hasRowHeaders: boolean
 }
 
 interface ContextMenuProps {
@@ -71,43 +67,31 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
   
   if (!menuState.type) return null
 
-  const handleAddRowAbove = () => {
-    const selectedRows = getSelectedRows()
-    const isCurrentRowFullySelected = isRowFullySelected(menuState.index)
+  const handleAddAt = (
+    type: 'row' | 'column',
+    direction: 'before' | 'after'
+  ) => {
+    const getSelected = type === 'row' ? getSelectedRows : getSelectedColumns
+    const isFullySelected = type === 'row' ? isRowFullySelected : isColumnFullySelected
+    const onAdd = type === 'row' ? onAddRow : onAddColumn
 
-    if (selectedRows.size > 1 && isCurrentRowFullySelected) {
-      // Multiple rows selected - add the same number of rows above the first selected row
-      const selectedRowArray = Array.from(selectedRows).sort((a, b) => a - b)
-      const firstRowIndex = selectedRowArray[0]
-      const selectedRowCount = selectedRows.size
-
-      // Add multiple rows at once using count parameter
-      onAddRow(firstRowIndex, selectedRowCount)
+    const selected = getSelected()
+    if (selected.size > 1 && isFullySelected(menuState.index)) {
+      if (direction === 'before') {
+        const first = Array.from(selected).sort((a, b) => a - b)[0]
+        onAdd(first, selected.size)
+      } else {
+        const last = Array.from(selected).sort((a, b) => b - a)[0]
+        onAdd(last + 1, selected.size)
+      }
     } else {
-      // Single row - add one row above
-      onAddRow(menuState.index)
+      onAdd(direction === 'before' ? menuState.index : menuState.index + 1)
     }
     onClose()
   }
 
-  const handleAddRowBelow = () => {
-    const selectedRows = getSelectedRows()
-    const isCurrentRowFullySelected = isRowFullySelected(menuState.index)
-
-    if (selectedRows.size > 1 && isCurrentRowFullySelected) {
-      // Multiple rows selected - add the same number of rows below the last selected row
-      const selectedRowArray = Array.from(selectedRows).sort((a, b) => b - a) // Sort descending
-      const lastRowIndex = selectedRowArray[0] // Highest index
-      const selectedRowCount = selectedRows.size
-
-      // Add multiple rows at once using count parameter
-      onAddRow(lastRowIndex + 1, selectedRowCount)
-    } else {
-      // Single row - add one row below
-      onAddRow(menuState.index + 1)
-    }
-    onClose()
-  }
+  const handleAddRowAbove = () => handleAddAt('row', 'before')
+  const handleAddRowBelow = () => handleAddAt('row', 'after')
 
   // Get selected rows
   const getSelectedRows = () => {
@@ -168,43 +152,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     onClose()
   }
 
-  const handleAddColumnLeft = () => {
-    const selectedColumns = getSelectedColumns()
-    const isCurrentColumnFullySelected = isColumnFullySelected(menuState.index)
-
-    if (selectedColumns.size > 1 && isCurrentColumnFullySelected) {
-      // Multiple columns selected - add the same number of columns to the left of the first selected column
-      const selectedColumnArray = Array.from(selectedColumns).sort((a, b) => a - b)
-      const firstColumnIndex = selectedColumnArray[0]
-      const selectedColumnCount = selectedColumns.size
-
-      // Add multiple columns at once using count parameter
-      onAddColumn(firstColumnIndex, selectedColumnCount)
-    } else {
-      // Single column - add one column to the left
-      onAddColumn(menuState.index)
-    }
-    onClose()
-  }
-
-  const handleAddColumnRight = () => {
-    const selectedColumns = getSelectedColumns()
-    const isCurrentColumnFullySelected = isColumnFullySelected(menuState.index)
-
-    if (selectedColumns.size > 1 && isCurrentColumnFullySelected) {
-      // Multiple columns selected - add the same number of columns to the right of the last selected column
-      const selectedColumnArray = Array.from(selectedColumns).sort((a, b) => b - a) // Sort descending
-      const lastColumnIndex = selectedColumnArray[0] // Highest index
-      const selectedColumnCount = selectedColumns.size
-
-      // Add multiple columns at once using count parameter
-      onAddColumn(lastColumnIndex + 1, selectedColumnCount)
-    } else {
-      // Single column - add one column to the right
-      onAddColumn(menuState.index + 1)
-    }
-    onClose()
-  }
+  const handleAddColumnLeft = () => handleAddAt('column', 'before')
+  const handleAddColumnRight = () => handleAddAt('column', 'after')
 
   const handleDeleteColumn = () => {
     const selectedColumns = getSelectedColumns()

--- a/webview-react/src/types/index.ts
+++ b/webview-react/src/types/index.ts
@@ -1,48 +1,11 @@
+import type { RowGitDiff, ColumnDiffInfo } from '../../../src/gitDiffTypes';
+
+export { GitDiffStatus, type RowGitDiff, type ColumnPositionChange, type ColumnDiffInfo } from '../../../src/gitDiffTypes';
+
 // ヘッダー設定
 export interface HeaderConfig {
   hasColumnHeaders: boolean  // 一番上の行を列ヘッダーとして扱う
   hasRowHeaders: boolean     // 一番左の列を行ヘッダーとして扱う
-}
-
-// Git差分状態
-export enum GitDiffStatus {
-  UNCHANGED = 'unchanged',
-  ADDED = 'added',
-  MODIFIED = 'modified',
-  DELETED = 'deleted'
-}
-
-// 行のGit差分情報
-export interface RowGitDiff {
-  row: number
-  status: GitDiffStatus
-  oldContent?: string  // 削除された行の内容（変更前の行を表示するため）
-  isDeletedRow?: boolean  // 削除行の表示用フラグ（実データ行ではない）
-  targetRow?: number  // 削除行のセル比較対象となる追加行のテーブル行番号
-}
-
-// 列の位置変更情報
-export interface ColumnPositionChange {
-  index: number              // 変更位置（追加の場合は新しい列番号、削除の場合は旧列番号）
-  type: 'added' | 'removed' | 'renamed'
-  header?: string            // ヘッダ名（わかる場合）
-  confidence: number         // 検出信頼度（0.0〜1.0）
-  oldIndex?: number          // renamed時の旧インデックス
-  newIndex?: number          // renamed時の新インデックス
-}
-
-// テーブルの列差分情報
-export interface ColumnDiffInfo {
-  oldColumnCount: number      // 変更前の列数
-  newColumnCount: number      // 変更後の列数
-  addedColumns: number[]      // 追加された列のインデックス（変更後の列番号）
-  deletedColumns: number[]    // 削除された列のインデックス（変更前の列番号）
-  oldHeaders?: string[]       // 変更前のヘッダ（削除列表示用）
-  newHeaders?: string[]       // 変更後のヘッダ
-  changeType?: 'added' | 'removed' | 'mixed' | 'none'  // 変更種別
-  positions?: ColumnPositionChange[]  // 各位置の変更詳細
-  mapping?: number[]          // 旧インデックス→新インデックスのマッピング（-1は削除）
-  heuristics?: string[]       // 適用した検出手法のメモ
 }
 
 // テーブルデータの型定義

--- a/webview-react/src/utils/autofillPatterns.ts
+++ b/webview-react/src/utils/autofillPatterns.ts
@@ -96,6 +96,12 @@ function detectNumericSeries(values: string[]): PatternInfo | null {
   return null
 }
 
+function calcConstantDiff(diffs: number[], epsilon = 0): { avgDiff: number; isConstant: boolean } {
+  const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length
+  const isConstant = diffs.every(d => Math.abs(d - avgDiff) <= epsilon)
+  return { avgDiff, isConstant }
+}
+
 /**
  * 日付パターンを検出（YYYY/MM/DD, YYYY-MM-DD, M/D, YYYY年M月D日 など）
  */
@@ -148,16 +154,13 @@ function detectDatePattern(values: string[]): PatternInfo | null {
     return null
   }
 
-  // 日数の差分を計算
   const diffs = []
   for (let i = 1; i < dates.length; i++) {
     const diff = (dates[i]!.getTime() - dates[i - 1]!.getTime()) / (1000 * 60 * 60 * 24)
     diffs.push(Math.round(diff))
   }
 
-  // 差分が一定かチェック
-  const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length
-  const isConstant = diffs.every(d => d === avgDiff)
+  const { avgDiff, isConstant } = calcConstantDiff(diffs)
 
   if (isConstant) {
     return {
@@ -172,83 +175,69 @@ function detectDatePattern(values: string[]): PatternInfo | null {
 }
 
 /**
- * 曜日パターンを検出
+ * 循環シーケンス（曜日・月など）の共通パターン検出
+ * nameLists[0] は完全一致、それ以降は大文字小文字を無視して照合する
  */
-function detectWeekdayPattern(values: string[]): PatternInfo | null {
-  const weekdays = ['日', '月', '火', '水', '木', '金', '土']
-  const weekdaysEn = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-  const weekdaysShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
-
+function detectCyclicSequence(
+  values: string[],
+  nameLists: string[][],
+  cycle: number,
+  type: FillPattern
+): PatternInfo | null {
   const indices = values.map(v => {
     const trimmed = v.trim()
-    let idx = weekdays.indexOf(trimmed)
-    if (idx === -1) idx = weekdaysEn.findIndex(w => w.toLowerCase() === trimmed.toLowerCase())
-    if (idx === -1) idx = weekdaysShort.findIndex(w => w.toLowerCase() === trimmed.toLowerCase())
+    let idx = nameLists[0].indexOf(trimmed)
+    for (let i = 1; i < nameLists.length && idx === -1; i++) {
+      idx = nameLists[i].findIndex(item => item.toLowerCase() === trimmed.toLowerCase())
+    }
     return idx
   })
 
-  if (indices.some(i => i === -1)) {
-    return null
-  }
+  if (indices.some(i => i === -1)) return null
 
-  // 連続しているかチェック
-  const diffs = []
+  const diffs: number[] = []
   for (let i = 1; i < indices.length; i++) {
-    diffs.push((indices[i] - indices[i - 1] + 7) % 7)
+    diffs.push((indices[i] - indices[i - 1] + cycle) % cycle)
   }
 
   const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length
-  const isConstant = diffs.every(d => d === avgDiff)
-
-  if (isConstant && avgDiff > 0) {
-    return {
-      type: 'weekday',
-      increment: avgDiff,
-      startValue: indices[indices.length - 1]
-    }
+  if (diffs.every(d => d === avgDiff) && avgDiff > 0) {
+    return { type, increment: avgDiff, startValue: indices[indices.length - 1] }
   }
 
   return null
 }
 
 /**
+ * 曜日パターンを検出
+ */
+function detectWeekdayPattern(values: string[]): PatternInfo | null {
+  return detectCyclicSequence(
+    values,
+    [
+      ['日', '月', '火', '水', '木', '金', '土'],
+      ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+      ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    ],
+    7,
+    'weekday'
+  )
+}
+
+/**
  * 月パターンを検出
  */
 function detectMonthPattern(values: string[]): PatternInfo | null {
-  const months = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月']
-  const monthsEn = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-  const monthsShort = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-
-  const indices = values.map(v => {
-    const trimmed = v.trim()
-    let idx = months.indexOf(trimmed)
-    if (idx === -1) idx = monthsEn.findIndex(m => m.toLowerCase() === trimmed.toLowerCase())
-    if (idx === -1) idx = monthsShort.findIndex(m => m.toLowerCase() === trimmed.toLowerCase())
-    return idx
-  })
-
-  if (indices.some(i => i === -1)) {
-    return null
-  }
-
-  // 連続しているかチェック
-  const diffs = []
-  for (let i = 1; i < indices.length; i++) {
-    diffs.push((indices[i] - indices[i - 1] + 12) % 12)
-  }
-
-  const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length
-  const isConstant = diffs.every(d => d === avgDiff)
-
-  if (isConstant && avgDiff > 0) {
-    return {
-      type: 'month',
-      increment: avgDiff,
-      startValue: indices[indices.length - 1]
-    }
-  }
-
-  return null
+  return detectCyclicSequence(
+    values,
+    [
+      ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'],
+      ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+      ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    ],
+    12,
+    'month'
+  )
 }
 
 /**
@@ -373,15 +362,12 @@ function detectTextWithNumber(values: string[]): PatternInfo | null {
     return null // パターンが一致しない
   }
 
-  // 数値の差分を計算
   const diffs = []
   for (let i = 1; i < patterns.length; i++) {
     diffs.push(patterns[i].number - patterns[i - 1].number)
   }
 
-  // 差分が一定かチェック
-  const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length
-  const isConstant = diffs.every(d => Math.abs(d - avgDiff) < 0.0001)
+  const { avgDiff, isConstant } = calcConstantDiff(diffs, 0.0001)
 
   if (isConstant) {
     // 最後のパターンから数値の形式を判定


### PR DESCRIPTION
## Overview
Refactoring

- Create src/gitDiffTypes.ts as single source of truth for GitDiffStatus, RowGitDiff, TableGitDiff, ColumnPositionChange, ColumnDiffInfo; remove duplicate definitions from gitDiffUtils.ts and webview-react/src/types/index.ts
- Remove local HeaderConfig definition from ContextMenu.tsx and import from shared types instead
- Extract handleAddAt() in ContextMenu.tsx to unify the four add-row/column handlers that shared identical logic
- Extract calcConstantDiff() in autofillPatterns.ts to unify repeated avgDiff/isConstant calculation in detectDatePattern and detectTextWithNumber